### PR TITLE
Use AssemblyQualifiedName instead of FullName and add serialization unit test

### DIFF
--- a/BrightWire.Net4/ExecutionGraph/Action/Backpropagate.cs
+++ b/BrightWire.Net4/ExecutionGraph/Action/Backpropagate.cs
@@ -21,7 +21,7 @@ namespace BrightWire.ExecutionGraph.Action
 
         public string Serialise()
         {
-            return _errorMetric.GetType().FullName;
+            return _errorMetric.GetType().AssemblyQualifiedName;
         }
 
         public IGraphData Execute(IGraphData input, IContext context)

--- a/BrightWire.Net4/ExecutionGraph/Action/BackpropagateThroughTime.cs
+++ b/BrightWire.Net4/ExecutionGraph/Action/BackpropagateThroughTime.cs
@@ -21,7 +21,7 @@ namespace BrightWire.ExecutionGraph.Action
 
         public string Serialise()
         {
-            return _errorMetric.GetType().FullName;
+            return _errorMetric.GetType().AssemblyQualifiedName;
         }
 
         public IGraphData Execute(IGraphData input, IContext context)

--- a/BrightWire.Net4/ExecutionGraph/Node/Helper/ExecuteBackwardAction.cs
+++ b/BrightWire.Net4/ExecutionGraph/Node/Helper/ExecuteBackwardAction.cs
@@ -33,7 +33,7 @@ namespace BrightWire.ExecutionGraph.Node.Helper
 
         protected override (string Description, byte[] Data) _GetInfo()
         {
-            return (_action.GetType().FullName, Encoding.UTF8.GetBytes(_action.Serialise()));
+            return (_action.GetType().AssemblyQualifiedName, Encoding.UTF8.GetBytes(_action.Serialise()));
         }
 
         protected override void _Initalise(GraphFactory factory, string description, byte[] data)

--- a/BrightWire.Net4/ExecutionGraph/Node/Helper/ExecuteForwardAction.cs
+++ b/BrightWire.Net4/ExecutionGraph/Node/Helper/ExecuteForwardAction.cs
@@ -24,7 +24,7 @@ namespace BrightWire.ExecutionGraph.Node.Helper
 
         protected override (string Description, byte[] Data) _GetInfo()
         {
-            return (_action.GetType().FullName, Encoding.UTF8.GetBytes(_action.Serialise()));
+            return (_action.GetType().AssemblyQualifiedName, Encoding.UTF8.GetBytes(_action.Serialise()));
         }
 
         protected override void _Initalise(GraphFactory factory, string description, byte[] data)

--- a/BrightWire.Net4/ExecutionGraph/Node/NodeBase.cs
+++ b/BrightWire.Net4/ExecutionGraph/Node/NodeBase.cs
@@ -133,7 +133,7 @@ namespace BrightWire.ExecutionGraph.Node
                 Name = _name,
                 Data = info.Data,
                 Description = info.Description,
-                TypeName = GetType().FullName
+                TypeName = GetType().AssemblyQualifiedName
             };
 
             // get the connected nodes

--- a/BrightWire.Net4/ExtensionMethods.ExecutionGraph.cs
+++ b/BrightWire.Net4/ExtensionMethods.ExecutionGraph.cs
@@ -111,7 +111,7 @@ namespace BrightWire
 
         internal static void Write(this BinaryWriter writer, IGradientDescentOptimisation optimisation)
         {
-            writer.Write(optimisation.GetType().FullName);
+            writer.Write(optimisation.GetType().AssemblyQualifiedName);
             optimisation.WriteTo(writer);
         }
 

--- a/UnitTests/SerializeTest.cs
+++ b/UnitTests/SerializeTest.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using BrightWire;
+using BrightWire.ExecutionGraph;
+using BrightWire.Models;
+using BrightWire.TrainingData.Artificial;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProtoBuf;
+
+namespace UnitTests
+{
+
+    [TestClass]
+    public class SerializeTest
+    {
+        public class CustomErrorMatrix : IErrorMetric
+        {
+            public IMatrix CalculateGradient(IContext context, IMatrix output, IMatrix targetOutput)
+            {
+                return targetOutput.Subtract(output);
+            }
+
+            public float Compute(FloatVector output, FloatVector targetOutput)
+            {
+                return output.MaximumIndex() == targetOutput.MaximumIndex() ? 1 : 0;
+            }
+
+            public bool DisplayAsPercentage => true;
+        }
+
+        static ILinearAlgebraProvider _cpu;
+        private static GraphModel bestNetwork;
+
+        static (GraphFactory, IDataSource) MakeGraphAndData()
+        {
+            var graph = new GraphFactory(_cpu);
+            var data = graph.CreateDataSource(And.Get());
+            return (graph, data);
+        }
+
+        [ClassInitialize]
+        public static void Load(TestContext context)
+        {
+            _cpu = BrightWireProvider.CreateLinearAlgebra(false);
+
+            var (graph, data) = MakeGraphAndData();
+            var engine = graph.CreateTrainingEngine(data);
+
+            var errorMetric = new CustomErrorMatrix();
+            graph.Connect(engine)
+                .AddFeedForward(1)
+                .Add(graph.SigmoidActivation())
+                .AddBackpropagation(errorMetric);
+            engine.Train(300, data, errorMetric, bn => bestNetwork = bn);
+            AssertEngineGetsGoodResults(engine, data);
+        }
+
+        private static void AssertEngineGetsGoodResults(IGraphEngine engine, IDataSource data)
+        {
+            var results = engine.Execute(data)?.FirstOrDefault();
+            Assert.IsNotNull(results);
+            bool Handle(FloatVector value) => value.Data[0] > 0.5f;
+            Debug.Assert(results.Output.Zip(results.Target, (result, target) => Handle(result) == Handle(target)).All(x => x));
+        }
+
+        [ClassCleanup]
+        public static void Cleanup()
+        {
+            _cpu.Dispose();
+        }
+
+        [TestMethod]
+        public void CreateFromExcuationGraph()
+        {
+            var (graph, data) = MakeGraphAndData();
+            var engine = graph.CreateEngine(bestNetwork.Graph);
+            AssertEngineGetsGoodResults(engine, data);
+        }
+
+        [TestMethod]
+        public void DeserlizeExcuationGraph()
+        {
+            var (graph, data) = MakeGraphAndData();
+            ExecutionGraph executionGraphReloaded = null;
+
+            using (var file = new MemoryStream())
+            {
+                Serializer.Serialize(file, bestNetwork.Graph);
+                file.Position = 0;
+                executionGraphReloaded = Serializer.Deserialize<ExecutionGraph>(file);
+            }
+            Assert.IsNotNull(executionGraphReloaded);
+            var engine = graph.CreateEngine(executionGraphReloaded);
+            AssertEngineGetsGoodResults(engine, data);
+        }
+
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -37,6 +37,26 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="ManagedCuda, Version=8.0.22.0, Culture=neutral, PublicKeyToken=242d898828717aa0, processorArchitecture=MSIL">
       <HintPath>..\packages\ManagedCuda-80.8.0.22\lib\net46\ManagedCuda.dll</HintPath>
@@ -81,6 +101,7 @@
     <Compile Include="MarkovModelTests.cs" />
     <Compile Include="NaiveBayesTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializeTest.cs" />
     <Compile Include="TreeBasedTests.cs" />
     <Compile Include="UnsupervisedTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
Type.GetType expects assembly-qualified names. FullName is okay for current-assembly and mscorlib types only.