### PR TITLE
- Fix GZIP error running MarkovChains, 404 link, autodownload training data show  and running sample names

### DIFF
--- a/BrightWire.Source/TrainingData/WellKnown/MNIST.cs
+++ b/BrightWire.Source/TrainingData/WellKnown/MNIST.cs
@@ -3,6 +3,7 @@ using BrightWire.TrainingData.Helper;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 
 namespace BrightWire.TrainingData.WellKnown
@@ -41,12 +42,12 @@ namespace BrightWire.TrainingData.WellKnown
             /// </summary>
             public byte[] Data => _data;
 
-	        /// <summary>
+            /// <summary>
             /// The image number (0-9)
             /// </summary>
             public int Label => _label;
 
-	        /// <summary>
+            /// <summary>
             /// Converts the image to one hot encoded float arrays
             /// </summary>
             public (FloatVector Data, FloatVector Label) AsFloatArray
@@ -75,19 +76,47 @@ namespace BrightWire.TrainingData.WellKnown
                     var rows = new List<FloatVector>();
                     var vector = data.Data.Data;
 
-                    for (var y = 0; y < SIZE; y++) {
+                    for (var y = 0; y < SIZE; y++)
+                    {
                         var row = new float[SIZE];
-                        for(var x = 0; x < SIZE; x++)
+                        for (var x = 0; x < SIZE; x++)
                             row[x] = vector[(y * SIZE) + x];
                         rows.Add(new FloatVector { Data = row });
                     }
-                    var tensor = new FloatTensor {
+                    var tensor = new FloatTensor
+                    {
                         Matrix = new[] {
                             FloatMatrix.Create(rows.ToArray())
                         }
                     };
                     return (tensor, data.Label);
                 }
+            }
+        }
+        
+        /// <summary>
+        /// Downloads MNIST data sets if they are missing.
+        /// </summary>
+        /// <param name="destPath"></param>
+        private static void AssurateMNISTData(string destPath)
+        {
+            if (!File.Exists(destPath))
+            {
+                FileInfo compressed = new FileInfo(destPath + ".gz");
+                compressed.Directory.Create();
+                var source = $"http://yann.lecun.com/exdb/mnist/{Path.GetFileNameWithoutExtension(compressed.Name).Replace(".", "-")}.gz";
+                Console.WriteLine("Downloading: {0}", source);
+                using (var client = new System.Net.WebClient())
+                    client.DownloadFile(source, compressed.FullName);
+
+
+
+                using (var src = compressed.OpenRead())
+                using (FileStream decompressedFileStream = File.Create(destPath))
+                using (GZipStream decompressionStream = new GZipStream(src, CompressionMode.Decompress))
+                    decompressionStream.CopyTo(decompressedFileStream);
+
+                Console.WriteLine("Decompressed: {0}", compressed.FullName);
             }
         }
 
@@ -99,27 +128,35 @@ namespace BrightWire.TrainingData.WellKnown
         /// <param name="total">Maximum number of images to load</param>
         public static IReadOnlyList<Image> Load(string labelPath, string imagePath, int total = int.MaxValue)
         {
+            AssurateMNISTData(labelPath);
             var labels = new List<byte>();
+           
             using (var file = new FileStream(labelPath, FileMode.Open, FileAccess.Read))
-            using (var reader = new BigEndianBinaryReader(file)) {
+            using (var reader = new BigEndianBinaryReader(file))
+            {
                 reader.ReadInt32();
                 var count = reader.ReadUInt32();
-                for (var i = 0; i < count && i < total; i++) {
+                for (var i = 0; i < count && i < total; i++)
+                {
                     labels.Add(reader.ReadByte());
                 }
             }
 
+            AssurateMNISTData(imagePath);
             var images = new List<byte[]>();
             using (var file = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
-            using (var reader = new BigEndianBinaryReader(file)) {
+            using (var reader = new BigEndianBinaryReader(file))
+            {
                 reader.ReadInt32();
                 var count = reader.ReadUInt32();
                 var numRows = reader.ReadUInt32();
                 var numCols = reader.ReadUInt32();
                 var imageSize = numRows * numCols;
-                for (var i = 0; i < count && i < total; i++) {
+                for (var i = 0; i < count && i < total; i++)
+                {
                     var imageData = new byte[imageSize];
-                    for (var j = 0; j < imageSize; j++) {
+                    for (var j = 0; j < imageSize; j++)
+                    {
                         imageData[j] = reader.ReadByte();
                     }
                     images.Add(imageData);

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Install-Package BrightWire
 
 It's highly likely that your GPU supports different CUDA capabilities than the precompiled `brightwire.ptx` in this repository. You can find what is your capability level [here](https://developer.nvidia.com/cuda-gpus). It's a number, ex. 3.0, 3.5, that you use for specifying `compute_XX` and `sm_XX` parameters.
 
-If you get an `ErrorNoBinaryForGPU` exception, that means you have to recompile. The instructions are [here](https://github.com/jdermody/brightwire/blob/master/LinearAlgebra/cuda/readme.txt).
+If you get an `ErrorNoBinaryForGPU` exception, that means you have to recompile. The instructions are [here](https://github.com/jdermody/brightwire/blob/master/BrightWire.CUDA.Net4.x64/cuda/readme.txt).
 
 Example command for NVIDIA GeForce GTX770M (CUDA 3.0)
 

--- a/SampleCode/IntegerAddition.cs
+++ b/SampleCode/IntegerAddition.cs
@@ -17,6 +17,8 @@ namespace BrightWire.SampleCode
 
         public static void IntegerAddition()
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(IntegerAddition)}\n");
+
             // generate 1000 random integer additions (split into training and test sets)
             var data = BinaryIntegers.Addition(1000, false).Split(0);
             using (var lap = BrightWireProvider.CreateLinearAlgebra(false)) {

--- a/SampleCode/IrisClassification.cs
+++ b/SampleCode/IrisClassification.cs
@@ -13,13 +13,18 @@ namespace BrightWire.SampleCode
         /// 
         /// Tutorial available at http://www.jackdermody.net/brightwire/article/Introduction_to_Bright_Wire
         /// </summary>
-        public static void IrisClassification()
+        public static void IrisClassification(string dataFilesPath)
         {
-            // download the iris data set
-            byte[] data;
-            using (var client = new WebClient()) {
-                data = client.DownloadData("https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data");
+            Console.WriteLine($"\nRunning {Console.Title = nameof(IrisClassification)}\n");
+            if (!File.Exists(dataFilesPath))
+            {
+                var src = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data";
+                var fi = new FileInfo(dataFilesPath);
+                fi.Directory.Create();
+                new WebClient().DownloadFile(src, dataFilesPath);
             }
+            byte[] data = File.ReadAllBytes(dataFilesPath);
+
 
             // parse the iris CSV into a data table
             var dataTable = new StreamReader(new MemoryStream(data)).ParseCSV(',');

--- a/SampleCode/IrisClustering.cs
+++ b/SampleCode/IrisClustering.cs
@@ -17,13 +17,17 @@ namespace BrightWire.SampleCode
             }
         }
 
-        public static void IrisClustering()
+        public static void IrisClustering(string dataFilesPath)
         {
-            // download the iris data set
-            byte[] data;
-            using (var client = new WebClient()) {
-                data = client.DownloadData("https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data");
+            Console.WriteLine($"\nRunning {Console.Title = nameof(IrisClustering)}\n");
+            if (!File.Exists(dataFilesPath))
+            {
+                var src = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data";
+                var fi = new FileInfo(dataFilesPath);
+                fi.Directory.Create();
+                new WebClient().DownloadFile(src, dataFilesPath);
             }
+            byte[] data = File.ReadAllBytes(dataFilesPath);
 
             // parse the iris CSV into a data table
             var dataTable = new StreamReader(new MemoryStream(data)).ParseCSV(',');

--- a/SampleCode/Linear.cs
+++ b/SampleCode/Linear.cs
@@ -12,6 +12,8 @@ namespace BrightWire.SampleCode
 	{
 		public static void SimpleLinearTest()
 		{
+			Console.WriteLine($"\nRunning {Console.Title = nameof(SimpleLinearTest)}\n");
+
 			var dataTableBuilder = BrightWireProvider.CreateDataTableBuilder();
 			dataTableBuilder.AddColumn(ColumnType.Float, "capital costs");
 			dataTableBuilder.AddColumn(ColumnType.Float, "labour costs");
@@ -79,6 +81,21 @@ namespace BrightWire.SampleCode
 		/// <param name="dataFilePath">The path to the csv file</param>
 		public static void PredictBicyclesWithLinearModel(string dataFilePath)
 		{
+			Console.WriteLine($"\nRunning {Console.Title = nameof(PredictBicyclesWithLinearModel)}\n");
+
+			if (!File.Exists(dataFilePath))
+			{
+				var destFile = new FileInfo(dataFilePath);
+				destFile.Directory.Parent.Create();
+				var url = "https://archive.ics.uci.edu/ml/machine-learning-databases/00275/Bike-Sharing-Dataset.zip";
+				Console.WriteLine($"Downloading data: {url}");
+				var compressed = new FileInfo(Path.Combine(destFile.Directory.Parent.FullName, destFile.Directory.Name + ".zip"));
+				new WebClient().DownloadFile(url, compressed.FullName);
+				System.IO.Compression.ZipFile.ExtractToDirectory(compressed.FullName, destFile.Directory.FullName);
+				Console.WriteLine($"Unzipped data: {destFile.Directory.FullName}");
+				Console.WriteLine();
+			}
+
 			var dataTable = _LoadBicyclesDataTable(dataFilePath);
 			var split = dataTable.Split(0);
 
@@ -112,6 +129,21 @@ namespace BrightWire.SampleCode
 		/// <param name="dataFilePath">The path to the csv file</param>
 		public static void PredictBicyclesWithNeuralNetwork(string dataFilePath)
 		{
+			Console.WriteLine($"\nRunning {Console.Title = nameof(PredictBicyclesWithNeuralNetwork)}\n");
+
+			if (!File.Exists(dataFilePath))
+			{
+				var destFile = new FileInfo(dataFilePath);
+				destFile.Directory.Parent.Create();
+				var url = "https://archive.ics.uci.edu/ml/machine-learning-databases/00275/Bike-Sharing-Dataset.zip";
+				Console.WriteLine($"Downloading data: {url}");
+				var compressed = new FileInfo(Path.Combine(destFile.Directory.Parent.FullName, destFile.Directory.Name + ".zip"));
+				new WebClient().DownloadFile(url, compressed.FullName);
+				System.IO.Compression.ZipFile.ExtractToDirectory(compressed.FullName, destFile.Directory.FullName);
+				Console.WriteLine($"Unzipped data: {destFile.Directory.FullName}"); 
+				Console.WriteLine();
+			}
+
 			var dataTable = _LoadBicyclesDataTable(dataFilePath);
 			var split = dataTable.Split(0);
 

--- a/SampleCode/MNIST.cs
+++ b/SampleCode/MNIST.cs
@@ -15,6 +15,8 @@ namespace BrightWire.SampleCode
         /// <param name="dataFilesPath">The path to a directory with the four extracted data files</param>
         public static void MNIST(string dataFilesPath)
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(MNIST)}\n");
+
             using (var lap = BrightWireProvider.CreateLinearAlgebra()) {
                 var graph = new GraphFactory(lap);
 

--- a/SampleCode/MarkovChains.cs
+++ b/SampleCode/MarkovChains.cs
@@ -11,11 +11,26 @@ namespace BrightWire.SampleCode
 {
     public partial class Program
     {
+
+        /// <summary>
+        /// Derived webclient that performs automatic decompression of content.
+        /// </summary>
+        public class WebClient : System.Net.WebClient
+        {
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                HttpWebRequest request = (HttpWebRequest)base.GetWebRequest(address);
+                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                return request;
+            }
+        }
+
         /// <summary>
         /// Builds a n-gram based language model and generates new text from the model
         /// </summary>
         public static void MarkovChains()
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(MarkovChains)}\n");
             // tokenise the novel "The Beautiful and the Damned" by F. Scott Fitzgerald
             List<IReadOnlyList<string>> sentences;
             using (var client = new WebClient()) {

--- a/SampleCode/MultiLabel.cs
+++ b/SampleCode/MultiLabel.cs
@@ -34,6 +34,16 @@ namespace BrightWire.SampleCode
 		/// <param name="dataFilePath"></param>
 		public static void MultiLabelSingleClassifier(string dataFilePath)
 		{
+			Console.WriteLine($"\nRunning {nameof(MultiLabelSingleClassifier)}\n");
+
+			if (!File.Exists(dataFilePath))
+            {
+				var url = "https://downloads.sourceforge.net/project/mulan/datasets/emotions.rar";
+				Console.WriteLine($"You must download data files to {dataFilePath} to run this example");
+				Console.WriteLine($" => Data files can be downloaded from {url}");
+				return;
+            }
+
 			var emotionData = _LoadEmotionData(dataFilePath);
 			var attributeColumns = Enumerable.Range(0, emotionData.ColumnCount - CLASSIFICATION_COUNT).ToList();
 			var classificationColumns = Enumerable.Range(emotionData.ColumnCount - CLASSIFICATION_COUNT, CLASSIFICATION_COUNT).ToList();
@@ -115,6 +125,16 @@ namespace BrightWire.SampleCode
 		/// <param name="dataFilePath"></param>
 		public static void MultiLabelMultiClassifiers(string dataFilePath)
 		{
+			Console.WriteLine($"\nRunning {nameof(MultiLabelSingleClassifier)}\n");
+
+			if (!File.Exists(dataFilePath))
+			{
+				var url = "https://downloads.sourceforge.net/project/mulan/datasets/emotions.rar";
+				Console.WriteLine($"You must download data files to {dataFilePath} to run this example");
+				Console.WriteLine($" => Data files can be downloaded from {url}");
+				return;
+			}
+
 			var emotionData = _LoadEmotionData(dataFilePath);
 			var attributeCount = emotionData.ColumnCount - CLASSIFICATION_COUNT;
 			var attributeColumns = Enumerable.Range(0, attributeCount).ToList();

--- a/SampleCode/Program.cs
+++ b/SampleCode/Program.cs
@@ -83,29 +83,30 @@ namespace BrightWire.SampleCode
 			// base path to a directory on your computer to store model files
 			const string ModelBasePath = @"c:\temp\";
 
-			// use the (faster) native MKL provider if available
-			//Control.UseNativeMKL();
+            // use the (faster) native MKL provider if available
+            //Control.UseNativeMKL();
 
-			//XOR();
-			//IrisClassification();
-			//IrisClustering();
-			//MarkovChains();
-			//MNIST(DataBasePath + @"mnist\");
-			//MNISTConvolutional(DataBasePath + @"mnist\"/*, ModelBasePath + @"mnist.dat"*/);
-			//SentimentClassification(DataBasePath + @"sentiment labelled sentences\");
-			//TextClustering(DataBasePath + @"[UCI] AAAI-14 Accepted Papers - Papers.csv", ModelBasePath);
-			//IntegerAddition();
-			//ReberPrediction();
-			//OneToMany();
-			//ManyToOne();
-			//SequenceToSequence();
-			//TrainWithSelu(DataBasePath + @"iris.data");
-			//SimpleLinearTest();
-			//PredictBicyclesWithLinearModel(DataBasePath + @"bikesharing\hour.csv");
-			//PredictBicyclesWithNeuralNetwork(DataBasePath + @"bikesharing\hour.csv");
-			//MultiLabelSingleClassifier(DataBasePath + @"emotions\emotions.arff");
-			//MultiLabelMultiClassifiers(DataBasePath + @"emotions\emotions.arff");
-			//StockData(DataBasePath + @"plotly\stockdata.csv");
-		}
+            XOR();
+            IrisClassification(DataBasePath + @"iris.data");
+            IrisClustering(DataBasePath + @"iris.data");
+            MarkovChains();
+            MNIST(DataBasePath + @"mnist\");
+			// CUDA required
+            // MNISTConvolutional(DataBasePath + @"mnist\"/*, ModelBasePath + @"mnist.dat"*/);
+            SentimentClassification(DataBasePath + @"sentiment labelled sentences\");
+            TextClustering(DataBasePath + @"[UCI] AAAI-14 Accepted Papers - Papers.csv", ModelBasePath);
+            IntegerAddition();
+            ReberPrediction();
+            OneToMany();
+            ManyToOne();
+            SequenceToSequence();
+            TrainWithSelu(DataBasePath + @"iris.data");
+            SimpleLinearTest();
+            PredictBicyclesWithLinearModel(DataBasePath + @"bikesharing\hour.csv");
+            PredictBicyclesWithNeuralNetwork(DataBasePath + @"bikesharing\hour.csv");
+            MultiLabelSingleClassifier(DataBasePath + @"emotions\emotions.arff");
+            MultiLabelMultiClassifiers(DataBasePath + @"emotions\emotions.arff");
+            StockData(DataBasePath + @"plotly\stockdata.csv");
+        }
 	}
 }

--- a/SampleCode/ReberPrediction.cs
+++ b/SampleCode/ReberPrediction.cs
@@ -12,6 +12,8 @@ namespace BrightWire.SampleCode
 	{
 		static void ReberPrediction()
 		{
+			Console.WriteLine($"\nRunning {Console.Title = nameof(ReberPrediction)}\n");
+
 			// generate 500 extended reber grammar training examples
 			var grammar = new ReberGrammar();
 			var sequences = grammar.GetExtended(10, 16).Take(500).ToList();

--- a/SampleCode/SampleCode.csproj
+++ b/SampleCode/SampleCode.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/SampleCode/Selu.cs
+++ b/SampleCode/Selu.cs
@@ -7,111 +7,126 @@ using System.IO;
 
 namespace BrightWire.SampleCode
 {
-	partial class Program
-	{
-		/// <summary>
-		/// Example of custom activation function, implemented from:
-		/// https://arxiv.org/abs/1706.02515
-		/// </summary>
-		class SeluActivation : NodeBase
-		{
-			const float ALPHA = 1.6732632423543772848170429916717f;
-			const float SCALE = 1.0507009873554804934193349852946f;
+    partial class Program
+    {
+        /// <summary>
+        /// Example of custom activation function, implemented from:
+        /// https://arxiv.org/abs/1706.02515
+        /// </summary>
+        class SeluActivation : NodeBase
+        {
+            const float ALPHA = 1.6732632423543772848170429916717f;
+            const float SCALE = 1.0507009873554804934193349852946f;
 
-			/// <summary>
-			/// Backpropagation of SELU activation
-			/// </summary>
-			class Backpropagation : SingleBackpropagationBase<SeluActivation>
-			{
-				public Backpropagation(SeluActivation source) : base(source) { }
+            /// <summary>
+            /// Backpropagation of SELU activation
+            /// </summary>
+            class Backpropagation : SingleBackpropagationBase<SeluActivation>
+            {
+                public Backpropagation(SeluActivation source) : base(source) { }
 
-				protected override IGraphData _Backpropagate(INode fromNode, IGraphData errorSignal, IContext context, IReadOnlyList<INode> parents)
-				{
-					var matrix = errorSignal.GetMatrix().AsIndexable();
-					var delta = context.LinearAlgebraProvider.CreateMatrix(matrix.RowCount, matrix.ColumnCount, (i, j) => {
-						var x = matrix[i, j];
-						if (x >= 0)
-							return SCALE;
-						return SCALE * ALPHA * BoundMath.Exp(x);
-					});
-					return errorSignal.ReplaceWith(delta);
-				}
-			}
+                protected override IGraphData _Backpropagate(INode fromNode, IGraphData errorSignal, IContext context, IReadOnlyList<INode> parents)
+                {
+                    var matrix = errorSignal.GetMatrix().AsIndexable();
+                    var delta = context.LinearAlgebraProvider.CreateMatrix(matrix.RowCount, matrix.ColumnCount, (i, j) =>
+                    {
+                        var x = matrix[i, j];
+                        if (x >= 0)
+                            return SCALE;
+                        return SCALE * ALPHA * BoundMath.Exp(x);
+                    });
+                    return errorSignal.ReplaceWith(delta);
+                }
+            }
 
-			public SeluActivation(string name = null) : base(name) { }
+            public SeluActivation(string name = null) : base(name) { }
 
-			public override void ExecuteForward(IContext context)
-			{
-				var matrix = context.Data.GetMatrix().AsIndexable();
-				var output = context.LinearAlgebraProvider.CreateMatrix(matrix.RowCount, matrix.ColumnCount, (i, j) => {
-					var x = matrix[i, j];
-					if (x >= 0)
-						return SCALE * x;
-					return SCALE * (ALPHA * BoundMath.Exp(x) - ALPHA);
-				});
-				_AddNextGraphAction(context, context.Data.ReplaceWith(output), () => new Backpropagation(this));
-			}
-		}
+            public override void ExecuteForward(IContext context)
+            {
+                var matrix = context.Data.GetMatrix().AsIndexable();
+                var output = context.LinearAlgebraProvider.CreateMatrix(matrix.RowCount, matrix.ColumnCount, (i, j) =>
+                {
+                    var x = matrix[i, j];
+                    if (x >= 0)
+                        return SCALE * x;
+                    return SCALE * (ALPHA * BoundMath.Exp(x) - ALPHA);
+                });
+                _AddNextGraphAction(context, context.Data.ReplaceWith(output), () => new Backpropagation(this));
+            }
+        }
 
-		public static void TrainWithSelu(string dataFilesPath)
-		{
-			using (var lap = BrightWireProvider.CreateLinearAlgebra()) {
-				var graph = new GraphFactory(lap);
+        public static void TrainWithSelu(string dataFilesPath)
+        {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(TrainWithSelu)}\n");
 
-				// parse the iris CSV into a data table and normalise
-				var dataTable = new StreamReader(new MemoryStream(File.ReadAllBytes(dataFilesPath))).ParseCSV(',').Normalise(NormalisationType.Standard);
+            if (!File.Exists(dataFilesPath))
+            {
+                var src = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data";
+                var fi = new FileInfo(dataFilesPath);
+                fi.Directory.Create();
+                new WebClient().DownloadFile(src, dataFilesPath);
+            }
+            byte[] data = File.ReadAllBytes(dataFilesPath);
 
-				// split the data table into training and test tables
-				var split = dataTable.Split(0);
-				var trainingData = graph.CreateDataSource(split.Training);
-				var testData = graph.CreateDataSource(split.Test);
 
-				// one hot encoding uses the index of the output vector's maximum value as the classification label
-				var errorMetric = graph.ErrorMetric.OneHotEncoding;
+            using (var lap = BrightWireProvider.CreateLinearAlgebra())
+            {
+                var graph = new GraphFactory(lap);
 
-				// configure the network properties
-				graph.CurrentPropertySet
-					.Use(graph.GradientDescent.RmsProp)
-					.Use(graph.GaussianWeightInitialisation(true, 0.1f, GaussianVarianceCalibration.SquareRoot2N, GaussianVarianceCount.FanInFanOut))
-				;
+                // parse the iris CSV into a data table and normalise
+                var dataTable = new StreamReader(new MemoryStream(File.ReadAllBytes(dataFilesPath))).ParseCSV(',').Normalise(NormalisationType.Standard);
 
-				// create the training engine and schedule a training rate change
-				const float TRAINING_RATE = 0.1f;
-				var engine = graph.CreateTrainingEngine(trainingData, TRAINING_RATE, batchSize: 128);
+                // split the data table into training and test tables
+                var split = dataTable.Split(0);
+                var trainingData = graph.CreateDataSource(split.Training);
+                var testData = graph.CreateDataSource(split.Test);
 
-				const int LAYER_SIZE = 64;
+                // one hot encoding uses the index of the output vector's maximum value as the classification label
+                var errorMetric = graph.ErrorMetric.OneHotEncoding;
 
-				Func<INode> activation = () => new SeluActivation();
-				//Func<INode> activation = () => graph.ReluActivation();
+                // configure the network properties
+                graph.CurrentPropertySet
+                    .Use(graph.GradientDescent.RmsProp)
+                    .Use(graph.GaussianWeightInitialisation(true, 0.1f, GaussianVarianceCalibration.SquareRoot2N, GaussianVarianceCount.FanInFanOut))
+                ;
 
-				// create the network with the custom activation function
-				graph.Connect(engine)
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(LAYER_SIZE)
-					.AddBatchNormalisation()
-					.Add(activation())
-					.AddFeedForward(trainingData.OutputSize)
-					.Add(graph.SoftMaxActivation())
-					.AddBackpropagation(errorMetric)
-				;
+                // create the training engine and schedule a training rate change
+                const float TRAINING_RATE = 0.1f;
+                var engine = graph.CreateTrainingEngine(trainingData, TRAINING_RATE, batchSize: 128);
 
-				const int TRAINING_ITERATIONS = 500;
-				engine.Train(TRAINING_ITERATIONS, testData, errorMetric, null, 50);
-			}
-		}
-	}
+                const int LAYER_SIZE = 64;
+
+                Func<INode> activation = () => new SeluActivation();
+                //Func<INode> activation = () => graph.ReluActivation();
+
+                // create the network with the custom activation function
+                graph.Connect(engine)
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(LAYER_SIZE)
+                    .AddBatchNormalisation()
+                    .Add(activation())
+                    .AddFeedForward(trainingData.OutputSize)
+                    .Add(graph.SoftMaxActivation())
+                    .AddBackpropagation(errorMetric)
+                ;
+
+                const int TRAINING_ITERATIONS = 500;
+                engine.Train(TRAINING_ITERATIONS, testData, errorMetric, null, 50);
+            }
+        }
+    }
 }

--- a/SampleCode/SequenceToSequence.cs
+++ b/SampleCode/SequenceToSequence.cs
@@ -11,6 +11,8 @@ namespace BrightWire.SampleCode
     {
         static void OneToMany()
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(OneToMany)}\n");
+
             var grammar = new SequenceGenerator(dictionarySize: 10, minSize: 5, maxSize: 5, noRepeat: true, isStochastic: false);
             var sequences = grammar.GenerateSequences().Take(1000).ToList();
             var builder = BrightWireProvider.CreateDataTableBuilder();
@@ -70,6 +72,8 @@ namespace BrightWire.SampleCode
 
         static void ManyToOne()
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(ManyToOne)}\n");
+
             var grammar = new SequenceGenerator(dictionarySize: 16, minSize: 3, maxSize: 6, noRepeat: true, isStochastic: false);
             var sequences = grammar.GenerateSequences().Take(1000).ToList();
             var builder = BrightWireProvider.CreateDataTableBuilder();
@@ -126,6 +130,8 @@ namespace BrightWire.SampleCode
 
         static void SequenceToSequence()
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(SequenceToSequence)}\n");
+
             const int SEQUENCE_LENGTH = 5;
             var grammar = new SequenceGenerator(8, SEQUENCE_LENGTH, SEQUENCE_LENGTH, true, false);
             var sequences = grammar.GenerateSequences().Take(2000).ToList();

--- a/SampleCode/StockData.cs
+++ b/SampleCode/StockData.cs
@@ -18,6 +18,16 @@ namespace BrightWire.SampleCode
 		/// </summary>
 		static void StockData(string dataFilePath)
 		{
+			Console.WriteLine($"\n{Console.Title = $"Running {nameof(StockData)}"}\n");
+
+			if (!File.Exists(dataFilePath))
+            {
+				var fi = new FileInfo(dataFilePath);
+				fi.Directory.Create();
+				var url = "https://raw.githubusercontent.com/plotly/datasets/master/stockdata.csv";
+				new WebClient().DownloadFile(url, fi.FullName);
+            }
+
 			// load and normalise the data
 			var dataSet = new StreamReader(dataFilePath).ParseCSV(',', true);
 			var normalised = dataSet.Normalise(NormalisationType.FeatureScale);

--- a/SampleCode/TextClustering.cs
+++ b/SampleCode/TextClustering.cs
@@ -66,6 +66,7 @@ namespace BrightWire.SampleCode
 
         static void _WriteClusters(string filePath, IReadOnlyList<IReadOnlyList<IVector>> clusters, Dictionary<IVector, AAAIDocument> documentTable)
         {
+            new FileInfo(filePath).Directory.Create();
             using (var writer = new StreamWriter(filePath)) {
                 foreach (var cluster in clusters) {
                     foreach (var item in cluster) {
@@ -89,7 +90,18 @@ namespace BrightWire.SampleCode
         /// <param name="outputPath">A directory to write the output files to</param>
         public static void TextClustering(string dataFilePath, string outputPath)
         {
+            Console.WriteLine($"\nRunning {Console.Title = nameof(TextClustering)}\n");
+
             IDataTable dataTable;
+            if (!File.Exists(dataFilePath))
+            {
+                var dest = new FileInfo(dataFilePath);
+                dest.Directory.Create();
+                var src = "https://archive.ics.uci.edu/ml/machine-learning-databases/00307/%5bUCI%5d%20AAAI-14%20Accepted%20Papers%20-%20Papers.csv";
+                new System.Net.WebClient()
+                    .DownloadFile(src, dest.FullName);
+
+            }
             using (var reader = new StreamReader(dataFilePath)) {
                 dataTable = reader.ParseCSV();
             }
@@ -159,6 +171,8 @@ namespace BrightWire.SampleCode
                     _WriteClusters(outputPath + "latent-kmeans.txt", vectorList3.KMeans(lap, allGroups.Count), lookupTable3);
                 }
             }
+
+            Console.WriteLine("Results saved to {0}", outputPath);
         }
     }
 }


### PR DESCRIPTION
- Fix index out of range exceptoin caused by not handling GZIP when running MarkovChains sample.
- Fix broken link on nvcc .cu/.ptx recompile instructions in readme.md.
- Auto-download missing data files for samples.
- Set `Console.Title` and the name of the sample being ran to standard out.
